### PR TITLE
fix: forward termination signals to the spawned child process

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import { spawn } from 'child_process';
+import os from 'os';
 import dotenv from 'dotenv';
 import { SecretsLoader } from './secrets-loader';
 
@@ -58,13 +59,33 @@ program
                 env: process.env,
             });
 
+            // Forward termination signals to the child so it can shut down
+            // gracefully. Without this, a SIGTERM/SIGINT delivered only to the
+            // wrapper (e.g. `kill <pid>`, pm2/systemd/docker stop) never reaches
+            // the actual process, leaving it running.
+            const forwardedSignals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'];
+            const forwardSignal = (signal: NodeJS.Signals) => {
+                if (!child.killed) {
+                    child.kill(signal);
+                }
+            };
+            for (const signal of forwardedSignals) {
+                process.on(signal, () => forwardSignal(signal));
+            }
+
             child.on('error', (error) => {
                 if (!quiet) console.error('Failed to execute command: ', error);
                 process.exit(1);
             });
 
-            child.on('exit', (code) => {
-                process.exit(code || 0);
+            child.on('exit', (code, signal) => {
+                // Mirror the child's fate: if it was killed by a signal, exit
+                // with the conventional 128 + signal-number code.
+                if (signal) {
+                    const signalNumber = (os.constants.signals as Record<string, number>)[signal] ?? 0;
+                    process.exit(128 + signalNumber);
+                }
+                process.exit(code ?? 0);
             });
         } catch (error: any) {
             if (!quiet) console.error('Failed to load secrets: ', error);


### PR DESCRIPTION
## What

`pandora-jar run -- <cmd>` now forwards `SIGINT`, `SIGTERM`, `SIGHUP`, and `SIGQUIT` to the child process it spawns, and mirrors the child's exit status (`128 + signal` when the child is signal-killed).

## Why this is needed (my use case)

I use `pandora-jar run -- ts-node index.ts` to run a long-lived backend that, on startup, opens a **lot** of persistent handles: Kafka consumers, ~40 BullMQ workers (each holding Redis connections), a DB pool, and an HTTP server. These keep the Node event loop alive indefinitely — which is exactly what a server should do.

The problem: **the process would not shut down.** Pressing Ctrl+C repeatedly did nothing; the only way to stop it was to force-kill the terminal.

### Root cause

The wrapper spawns the command but installs **no signal handling** — it only listens for the child's `error`/`exit` events:

```js
const child = spawn(cmd, cmdArgs, { stdio: 'inherit', shell: true, env: process.env });
child.on('error', ...);
child.on('exit', code => process.exit(code || 0));
```

This relies entirely on the OS delivering the signal to the whole foreground process group. That works *by luck* for interactive Ctrl+C, but it breaks down for the cases that matter:

- A signal sent **only to the wrapper PID** — `kill <pid>`, and crucially **pm2 / systemd / `docker stop`** (which we use in production) — never reaches the child. The app keeps running; graceful-shutdown handlers never fire.
- The `shell: true` layer (`sh -c "<cmd>"`) inserts a subshell between the wrapper and the real process, making process-group assumptions even more fragile.

Net effect: any app with open handles run under `pandora-jar` can't be cleanly stopped by a process manager, and won't drain in-flight work on deploy.

### Fix

Explicitly forward the standard termination signals to the child so its own shutdown logic runs, and propagate the child's exit status back up so process managers observe the correct result:

```js
const forwardedSignals = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'];
for (const signal of forwardedSignals) {
  process.on(signal, () => { if (!child.killed) child.kill(signal); });
}

child.on('exit', (code, signal) => {
  if (signal) {
    const n = os.constants.signals[signal] ?? 0;
    process.exit(128 + n);
  }
  process.exit(code ?? 0);
});
```

## Impact / compatibility

- No CLI surface change; `--quiet` and all existing options are untouched.
- Behaviour only *adds* signal propagation; the happy-path exit handling is unchanged.
- Makes `pandora-jar` safe to use as the entrypoint under pm2/systemd/Docker, where correct signal delivery is required for graceful shutdown and zero-downtime deploys.

## Testing

- Built with `tsc`; output verified to contain both `--quiet` and the new signal forwarding.
- `pandora-jar run -- ts-node index.ts` then Ctrl+C now triggers the app's graceful shutdown instead of hanging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CLI process signal handling to properly forward termination signals to child processes and report appropriate exit codes when processes are terminated by signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->